### PR TITLE
Allow Keep Alives for 201 & 404 Responses.

### DIFF
--- a/lib/evma_httpserver/response.rb
+++ b/lib/evma_httpserver/response.rb
@@ -98,7 +98,7 @@ module EventMachine
 			send_headers
 			send_body
 			send_trailer
-			close_connection_after_writing unless (@keep_connection_open and (@status || 200) == 200)
+			close_connection_after_writing unless (@keep_connection_open and (@status || 200) < 500)
 		end
 
 		# Send the headers out in alpha-sorted order. This will degrade performance to some

--- a/test/test_response.rb
+++ b/test/test_response.rb
@@ -103,6 +103,57 @@ class TestHttpResponse < Test::Unit::TestCase
     assert( ! a.closed_after_writing )
   end
 
+  def test_send_response_no_close_with_a_404_response
+    a = EventMachine::HttpResponse.new
+    a.status = 404
+    a.content_type "text/plain"
+    a.content = "ABC"
+    a.keep_connection_open
+    a.send_response
+    assert_equal([
+           "HTTP/1.1 404 ...\r\n",
+           "Content-length: 3\r\n",
+           "Content-type: text/plain\r\n",
+           "\r\n",
+           "ABC"
+    ].join, a.output_data)
+    assert( ! a.closed_after_writing )
+  end
+
+  def test_send_response_no_close_with_a_201_response
+    a = EventMachine::HttpResponse.new
+    a.status = 201
+    a.content_type "text/plain"
+    a.content = "ABC"
+    a.keep_connection_open
+    a.send_response
+    assert_equal([
+           "HTTP/1.1 201 ...\r\n",
+           "Content-length: 3\r\n",
+           "Content-type: text/plain\r\n",
+           "\r\n",
+           "ABC"
+    ].join, a.output_data)
+    assert( ! a.closed_after_writing )
+  end
+
+  def test_send_response_no_close_with_a_500_response
+    a = EventMachine::HttpResponse.new
+    a.status = 500
+    a.content_type "text/plain"
+    a.content = "ABC"
+    a.keep_connection_open
+    a.send_response
+    assert_equal([
+           "HTTP/1.1 500 ...\r\n",
+           "Content-length: 3\r\n",
+           "Content-type: text/plain\r\n",
+           "\r\n",
+           "ABC"
+    ].join, a.output_data)
+    assert( a.closed_after_writing )
+  end
+
   def test_send_response_multiple_times
     a = EventMachine::HttpResponse.new
     a.status = 200


### PR DESCRIPTION
Our app (used internally in @reevoo) is posting many (1000/s) small requests over SSL with certificate verification on either side. Connection setups are very expensive, so we use keep alive and connection recycling.

Our service responds with a 201 when a record is posted and a 404 when a get on a missing record happens.

This patch means that only 5xx responses force a connection reset.

I've also added some test coverage.

Let me know what you think.
