### PR TITLE
Allow an HTTP status reason to be set

### DIFF
--- a/lib/evma_httpserver/response.rb
+++ b/lib/evma_httpserver/response.rb
@@ -49,7 +49,7 @@ module EventMachine
 	# EventMachine::Connection.
 	#
 	class HttpResponse
-		attr_accessor :status, :content, :headers, :chunks, :multiparts
+		attr_accessor :status, :status_reason, :content, :headers, :chunks, :multiparts
 
 		def initialize
 			@headers = {}
@@ -111,7 +111,8 @@ module EventMachine
 			fixup_headers
 
 			ary = []
-			ary << "HTTP/1.1 #{@status || 200} ...\r\n"
+			@status, @status_reason = 200, 'OK' unless @status
+			ary << "HTTP/1.1 #{@status} #{@status_reason || '...'}\r\n"
 			ary += generate_header_lines(@headers)
 			ary << "\r\n"
 

--- a/test/test_delegated.rb
+++ b/test/test_delegated.rb
@@ -65,9 +65,10 @@ class TestDelegatedHttpResponse < Test::Unit::TestCase
 		d = D.new
 		a = EM::DelegatedHttpResponse.new( d )
 		a.status = 200
+		a.status_reason = "OK"
 		a.send_response
 		assert_equal([
-			     "HTTP/1.1 200 ...\r\n",
+			     "HTTP/1.1 200 OK\r\n",
 			     "Content-length: 0\r\n",
 			     "\r\n"
 		].join, d.output_data)
@@ -78,11 +79,12 @@ class TestDelegatedHttpResponse < Test::Unit::TestCase
 		d = D.new
 		a = EM::DelegatedHttpResponse.new( d )
 		a.status = 200
+		a.status_reason = "OK"
 		a.content_type "text/plain"
 		a.content = "ABC"
 		a.send_response
 		assert_equal([
-			     "HTTP/1.1 200 ...\r\n",
+			     "HTTP/1.1 200 OK\r\n",
 			     "Content-length: 3\r\n",
 			     "Content-type: text/plain\r\n",
 			     "\r\n",
@@ -95,12 +97,13 @@ class TestDelegatedHttpResponse < Test::Unit::TestCase
 		d = D.new
 		a = EM::DelegatedHttpResponse.new( d )
 		a.status = 200
+		a.status_reason = "OK"
 		a.content_type "text/plain"
 		a.content = "ABC"
 		a.keep_connection_open
 		a.send_response
 		assert_equal([
-			     "HTTP/1.1 200 ...\r\n",
+			     "HTTP/1.1 200 OK\r\n",
 			     "Content-length: 3\r\n",
 			     "Content-type: text/plain\r\n",
 			     "\r\n",
@@ -122,9 +125,10 @@ class TestDelegatedHttpResponse < Test::Unit::TestCase
 		d = D.new
 		a = EM::DelegatedHttpResponse.new( d )
 		a.status = 200
+		a.status_reason = "OK"
 		a.send_headers
 		assert_equal([
-			     "HTTP/1.1 200 ...\r\n",
+			     "HTTP/1.1 200 OK\r\n",
 			     "Content-length: 0\r\n",
 			     "\r\n"
 		].join, d.output_data)
@@ -143,7 +147,7 @@ class TestDelegatedHttpResponse < Test::Unit::TestCase
 		a.keep_connection_open
 		a.send_response
 		assert_equal([
-			     "HTTP/1.1 200 ...\r\n",
+			     "HTTP/1.1 200 OK\r\n",
 			     "Transfer-encoding: chunked\r\n",
 			     "\r\n",
 			     "3\r\n",
@@ -166,7 +170,7 @@ class TestDelegatedHttpResponse < Test::Unit::TestCase
 		a.chunk "GHI"
 		a.send_response
 		assert_equal([
-			     "HTTP/1.1 200 ...\r\n",
+			     "HTTP/1.1 200 OK\r\n",
 			     "Transfer-encoding: chunked\r\n",
 			     "\r\n",
 			     "3\r\n",

--- a/test/test_response.rb
+++ b/test/test_response.rb
@@ -61,6 +61,7 @@ class TestHttpResponse < Test::Unit::TestCase
   def test_send_response
     a = EventMachine::HttpResponse.new
     a.status = 200
+    a.status_reason = "..."
     a.send_response
     assert_equal([
            "HTTP/1.1 200 ...\r\n",
@@ -73,11 +74,12 @@ class TestHttpResponse < Test::Unit::TestCase
   def test_send_response_1
     a = EventMachine::HttpResponse.new
     a.status = 200
+    a.status_reason = "OK"
     a.content_type "text/plain"
     a.content = "ABC"
     a.send_response
     assert_equal([
-           "HTTP/1.1 200 ...\r\n",
+           "HTTP/1.1 200 OK\r\n",
            "Content-length: 3\r\n",
            "Content-type: text/plain\r\n",
            "\r\n",
@@ -89,12 +91,13 @@ class TestHttpResponse < Test::Unit::TestCase
   def test_send_response_no_close
     a = EventMachine::HttpResponse.new
     a.status = 200
+    a.status_reason = "OK"
     a.content_type "text/plain"
     a.content = "ABC"
     a.keep_connection_open
     a.send_response
     assert_equal([
-           "HTTP/1.1 200 ...\r\n",
+           "HTTP/1.1 200 OK\r\n",
            "Content-length: 3\r\n",
            "Content-type: text/plain\r\n",
            "\r\n",
@@ -115,9 +118,10 @@ class TestHttpResponse < Test::Unit::TestCase
   def test_send_headers
     a = EventMachine::HttpResponse.new
     a.status = 200
+    a.status_reason = "OK"
     a.send_headers
     assert_equal([
-           "HTTP/1.1 200 ...\r\n",
+           "HTTP/1.1 200 OK\r\n",
            "Content-length: 0\r\n",
            "\r\n"
     ].join, a.output_data)
@@ -135,7 +139,7 @@ class TestHttpResponse < Test::Unit::TestCase
     a.keep_connection_open
     a.send_response
     assert_equal([
-           "HTTP/1.1 200 ...\r\n",
+           "HTTP/1.1 200 OK\r\n",
            "Transfer-encoding: chunked\r\n",
            "\r\n",
            "3\r\n",
@@ -157,7 +161,7 @@ class TestHttpResponse < Test::Unit::TestCase
     a.chunk "GHI"
     a.send_response
     assert_equal([
-           "HTTP/1.1 200 ...\r\n",
+           "HTTP/1.1 200 OK\r\n",
            "Transfer-encoding: chunked\r\n",
            "\r\n",
            "3\r\n",


### PR DESCRIPTION
Allow a reason phrase for the http response, and for the default 200 status code return OK as the default reason phrase. Noticed this because Pingdom was not able to handle "HTTP/1.1 200 ..." in the http header, "HTTP/1.1 200 OK" was expected.
