### PR TITLE
cert_chain must not be nil

### DIFF
--- a/eventmachine_httpserver.gemspec
+++ b/eventmachine_httpserver.gemspec
@@ -6,7 +6,6 @@ Gem::Specification.new do |s|
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Francis Cianfrocca"]
-  s.cert_chain = nil
   s.date = %q{2007-03-16}
   s.description = %q{}
   s.email = %q{garbagecat10@gmail.com}


### PR DESCRIPTION
when run rake gem:build, I got "cert_chain must not be nil" error.

delete the line works for me, and you can fix it the other way.
