### PR TITLE
Fix cert_chain must not be nil

### DIFF
--- a/eventmachine_httpserver.gemspec
+++ b/eventmachine_httpserver.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |s|
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Francis Cianfrocca"]
-  s.cert_chain = nil
+  s.cert_chain = []
   s.date = %q{2007-03-16}
   s.description = %q{}
   s.email = %q{garbagecat10@gmail.com}


### PR DESCRIPTION
Fix the following build breaks

ERROR:  While executing gem ... (Gem::InvalidSpecificationException)
    cert_chain must not be nil

Thanks!
