### PR TITLE
dont set content lenth header if there is no content

### DIFF
--- a/lib/evma_httpserver/response.rb
+++ b/lib/evma_httpserver/response.rb
@@ -201,8 +201,6 @@ module EventMachine
       elsif @multiparts
         @multipart_boundary = self.class.concoct_multipart_boundary
         @headers["Content-Type"] = "multipart/x-mixed-replace; boundary=\"#{@multipart_boundary}\""
-      else
-        @headers["Content-Length"] = 0
       end
     end
 


### PR DESCRIPTION
I find this useful when implementing responses to HEAD http method for cache control.
