### PR TITLE
Update eventmachine_httpserver.gemspec

### DIFF
--- a/eventmachine_httpserver.gemspec
+++ b/eventmachine_httpserver.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.email = %q{garbagecat10@gmail.com}
   s.extensions = ["ext/extconf.rb"]
   s.extra_rdoc_files = ["docs/COPYING", "docs/README", "docs/RELEASE_NOTES"]
-  s.files = ["README", "Rakefile", "docs/COPYING", "docs/README", "docs/RELEASE_NOTES", "eventmachine_httpserver.gemspec", "eventmachine_httpserver.gemspec.tmpl", "ext/extconf.rb", "ext/http.cpp", "ext/http.h", "ext/rubyhttp.cpp", "lib/evma_httpserver.rb", "lib/evma_httpserver/response.rb", "test/test_app.rb", "test/test_delegated.rb", "test/test_response.rb"]
+  s.files = ["README.md", "Rakefile", "docs/COPYING", "docs/README", "docs/RELEASE_NOTES", "eventmachine_httpserver.gemspec", "eventmachine_httpserver.gemspec.tmpl", "ext/extconf.rb", "ext/http.cpp", "ext/http.h", "ext/rubyhttp.cpp", "lib/evma_httpserver.rb", "lib/evma_httpserver/response.rb", "test/test_app.rb", "test/test_delegated.rb", "test/test_response.rb"]
   s.homepage = %q{https://github.com/eventmachine/evma_httpserver}
   s.rdoc_options = ["--title", "EventMachine_HttpServer", "--main", "docs/README", "--line-numbers"]
   s.require_paths = ["lib"]


### PR DESCRIPTION
Readme was moved to README.md and since gemspec is invalid and bundler do not compile it when install directly from github.